### PR TITLE
Fix mmap error check to check for MAP_FAILED instead of NULL

### DIFF
--- a/bf_compile_and_go.cpp
+++ b/bf_compile_and_go.cpp
@@ -296,7 +296,7 @@ bool BrainfuckCompileAndGo::init(string::const_iterator start,
       executable_size_,
       PROT_READ | PROT_WRITE,
       MAP_PRIVATE | MAP_ANON, -1, 0);
-  if (executable_ == NULL) {
+  if (executable_ == MAP_FAILED) {
     fprintf(stderr, "Error making memory executable: %s\n", strerror(errno));
     return false;
   }


### PR DESCRIPTION
Manpage says that `mmap` returns `MAP_FAILED` (i.e. `(void*) -1`) on error, not `NULL` (i.e. `0`).